### PR TITLE
Added @foo::footer as well as @foo::header

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -275,6 +275,8 @@ case <f.ruleIndex>:
 
 	<atn>
 }
+
+<namedActions.footer>
 >>
 
 vocabulary(literalNames, symbolicNames) ::= <<
@@ -960,6 +962,8 @@ public class <lexer.name> extends <superClass; null="Lexer"> {
 	<dumpActions(lexer, "", actionFuncs, sempredFuncs)>
 	<atn>
 }
+
+<namedActions.footer>
 >>
 
 SerializedATN(model) ::= <<


### PR DESCRIPTION
This one line in this one file is all that's needed to support footers as well as headers in actionful grammars!
This is important because with footers you can include a supertype in the .java file.  You could add a class as a static nested class in ::members already, but classes can't extend any of their nested classes (not for any technical reason I think, just philosophical java reasons I guess)

But including superclasses in footers allows them to use the same package selection mechanism the generated lexer/parser classes do, instead of hardcoding the package name into a separate file :>

(In the other branch that hopefully won't show up in the pull request, I only added it to the lexer not the parser, "patch-footer-both" has both)

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->